### PR TITLE
feat(redirect): 适配 Bilibili 中间页短链接

### DIFF
--- a/src/scripts-header/redirect.js
+++ b/src/scripts-header/redirect.js
@@ -61,6 +61,7 @@ export default isProd =>
 // @match        *://*.yuque.com/r/goto*
 // @match        *://hd.nowcoder.com/link.html*
 // @match        *://game.bilibili.com/linkfilter/*
+// @match        *://www.bilibili.com/york/link-middle-page/pc*
 // @match        *://sspai.com/link*
 // @match        *://niu.sspai.com/link*
 // @match        *://jump.5ch.net/*

--- a/src/scripts/redirect/sites/index.ts
+++ b/src/scripts/redirect/sites/index.ts
@@ -302,9 +302,12 @@ const sites: Site[] = [
   },
   {
     name: '哔哩哔哩',
-    test: 'game.bilibili.com/linkfilter/',
+    test: [
+      'game.bilibili.com/linkfilter/',
+      'www.bilibili.com/york/link-middle-page/pc',
+    ],
     use: () => ({
-      query: 'url',
+      link: parse().url || parse().redirect_url,
     }),
   },
   {


### PR DESCRIPTION
## 改动说明

新增 Bilibili 外链中间页 `www.bilibili.com/york/link-middle-page/pc` 的自动跳转适配。

### 示例链接

```
https://www.bilibili.com/york/link-middle-page/pc?navhide=1&rid=1226712684902219777&r_type=0&redirect_url=https%3A%2F%2Fgithub.com%2FYunhaoFu%2Fdsv4ga-news-gather
```

### 改动文件

| 文件 | 说明 |
|------|------|
| `src/scripts/redirect/sites/index.ts` | 扩展现有「哔哩哔哩」规则：test 新增 `www.bilibili.com/york/link-middle-page/pc`，use 改为 `parse().url \|\| parse().redirect_url` 兼容两种参数名 |
| `src/scripts-header/redirect.js` | 新增 `@match *://www.bilibili.com/york/link-middle-page/pc*` |